### PR TITLE
Convert remaining #include statements to use gz/

### DIFF
--- a/cli/src/cli_TEST.cc
+++ b/cli/src/cli_TEST.cc
@@ -20,7 +20,7 @@
 #include <memory>
 
 #include <gz/utils/cli/CLI.hpp>
-#include <gz/utils/cli/IgnitionFormatter.hpp>
+#include <gz/utils/cli/GzFormatter.hpp>
 
 /////////////////////////////////////////////////
 struct TestOptions

--- a/cli/src/cli_TEST.cc
+++ b/cli/src/cli_TEST.cc
@@ -19,8 +19,8 @@
 
 #include <memory>
 
-#include <ignition/utils/cli/CLI.hpp>
-#include <ignition/utils/cli/IgnitionFormatter.hpp>
+#include <gz/utils/cli/CLI.hpp>
+#include <gz/utils/cli/IgnitionFormatter.hpp>
 
 /////////////////////////////////////////////////
 struct TestOptions

--- a/src/Environment.cc
+++ b/src/Environment.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include <ignition/utils/Environment.hh>
+#include <gz/utils/Environment.hh>
 
 #include <cstdlib>
 #include <iostream>

--- a/src/Environment_TEST.cc
+++ b/src/Environment_TEST.cc
@@ -17,7 +17,7 @@
 
 #include <gtest/gtest.h>
 
-#include <ignition/utils/Environment.hh>
+#include <gz/utils/Environment.hh>
 
 using namespace ignition;
 

--- a/src/NeverDestroyed_TEST.cc
+++ b/src/NeverDestroyed_TEST.cc
@@ -15,7 +15,7 @@
  *
  */
 
-#include "ignition/utils/NeverDestroyed.hh"
+#include "gz/utils/NeverDestroyed.hh"
 
 #include <gtest/gtest.h>
 

--- a/test/integration/implptr/ImplPtr_TEST.cc
+++ b/test/integration/implptr/ImplPtr_TEST.cc
@@ -17,7 +17,7 @@
 
 #include <gtest/gtest.h>
 
-#include <ignition/utils/ImplPtr.hh>
+#include <gz/utils/ImplPtr.hh>
 #include "implptr_test_classes.hh"
 
 using namespace ignition::implptr_test_classes;

--- a/test/integration/implptr/implptr_test_classes.hh
+++ b/test/integration/implptr/implptr_test_classes.hh
@@ -18,8 +18,8 @@
 #ifndef IGNITION_UTILS_TEST_IMPLPTR_TEST_CLASSES_HH_
 #define IGNITION_UTILS_TEST_IMPLPTR_TEST_CLASSES_HH_
 
-#include <ignition/utils/ImplPtr.hh>
-#include <ignition/utils/Export.hh>
+#include <gz/utils/ImplPtr.hh>
+#include <gz/utils/Export.hh>
 
 #include <functional>
 #include <string>


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebo-tooling/release-tools/issues/711, follow-up to #52

## Summary

The ignition headers have been migrated to `include/gz/`, and this converts the remaining `#include <ignition/*>` statements to `#include <gz/*>`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
