### PR TITLE
cli_TEST: Fix compatibility with CLI11 2.0

### DIFF
--- a/cli/src/cli_TEST.cc
+++ b/cli/src/cli_TEST.cc
@@ -86,7 +86,7 @@ std::shared_ptr<TestOptions> addFlags(CLI::App &_app)
   excludesB->excludes(excludesA);
 
   _app.add_option("--default-value", opt->defaultValueOption,
-      "Option with default value", true);
+      "Option with default value")->capture_default_str();
 
   return opt;
 }


### PR DESCRIPTION
# 🦟 Bug fix

Fixes compatibility with CLI11 2.0

## Summary

If `IGN_UTILS_VENDOR_CLI11` is set to OFF and `CLI11` >= 2.0 was used, the compilation failed with:
~~~
2022-05-13T06:56:23.1223336Z [ 87%] Building CXX object cli/src/CMakeFiles/UNIT_cli_TEST.dir/cli_TEST.cc.o
2022-05-13T06:56:25.1811635Z /home/conda/feedstock_root/build_artifacts/libignition-utils1_1652424878233/work/cli/src/cli_TEST.cc: In function 'std::shared_ptr<TestOptions> addFlags(CLI::App&)':
2022-05-13T06:56:25.1816895Z /home/conda/feedstock_root/build_artifacts/libignition-utils1_1652424878233/work/cli/src/cli_TEST.cc:89:40: error: no matching function for call to 'CLI::App::add_option(const char [16], float&, const char [26], bool)'
2022-05-13T06:56:25.1817859Z    89 |       "Option with default value", true);
2022-05-13T06:56:25.1818289Z       |                                        ^
2022-05-13T06:56:25.1819571Z In file included from /home/conda/feedstock_root/build_artifacts/libignition-utils1_1652424878233
~~~

This is due to the the following change described in the changelog ( https://github.com/CLIUtils/CLI11/blob/main/CHANGELOG.md#version-20-simplification ):
> The final "defaulted" bool has been removed, use ->capture_default_str() instead. Use app.option_defaults()->always_capture_default() to set this for all future options. https://github.com/CLIUtils/CLI11/pull/597

Fortunatly, the suggested change works fine also with the vendored copy of CLI11, so we can just switch to that version to be future proof.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [x] Updated documentation (as needed)
- [x] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [x] `codecheck` passed (See [contributing](https://ignitionrobotics.org/docs/all/contributing#contributing-code))
- [x] All tests passed (See [test coverage](https://ignitionrobotics.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Aignitionrobotics+repo%3Aosrf%2Fsdformat+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

