### PR TITLE
Add code coverage ignore file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ project(ignition-utils1 VERSION 1.4.0)
 # Find ignition-cmake
 #============================================================================
 # If you get an error at this line, you need to install ignition-cmake
-find_package(ignition-cmake2 2.0.0 REQUIRED)
+find_package(ignition-cmake2 2.14.0 REQUIRED)
 
 #============================================================================
 # Configure the project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,8 +39,6 @@ endif()
 #============================================================================
 # Configure the build
 #============================================================================
-configure_file("${PROJECT_SOURCE_DIR}/coverage.ignore.in"
-               ${PROJECT_BINARY_DIR}/coverage.ignore)
 ign_configure_build(QUIT_IF_BUILD_ERRORS
   COMPONENTS cli)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,8 @@ endif()
 #============================================================================
 # Configure the build
 #============================================================================
+configure_file("${PROJECT_SOURCE_DIR}/coverage.ignore.in"
+               ${PROJECT_BINARY_DIR}/coverage.ignore)
 ign_configure_build(QUIT_IF_BUILD_ERRORS
   COMPONENTS cli)
 

--- a/coverage.ignore.in
+++ b/coverage.ignore.in
@@ -1,0 +1,1 @@
+cli/include/vendored-cli/*


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebosim/gz-sim/issues/1575

Requires: https://github.com/gazebosim/gz-cmake/pull/279

## Summary
Adds `coverage.ignore.in`, which lists files to ignore in the coverage report 

## Test it
In the root of your colcon workspace:

```bash
colcon build --cmake-args -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Coverage --merge-install --packages-select ignition-utils1 --event-handlers console_direct+

# when testing with this PR, you should see a message:
# Ignore coverage additions: '/path/to/ws/src/ign-utils/cli/include/vendored-cli/*'

cd build/ignition-utils1
make test -j8
make coverage VERBOSE=1 -j8

# when testing with PR, you should see the file listed in the command:
# /usr/bin/lcov -q --remove coverage.info '*/test/*' '/usr/*' '*_TEST*' '*.cxx' 'moc_*.cpp' 'qrc_*.cpp' '*.pb.*' '*/build/*' '*/install/*' '/path/to/ws/src/ign-utils/cli/include/vendored-cli/*' --output-file coverage.info.cleaned

firefox coverage/index.html
```

**Before PR**
![after_without_utilsPR](https://user-images.githubusercontent.com/8602001/180572503-481f66b8-7194-4695-bb27-000e039eb8db.png)

**After PR**
![after_with_utilsPR](https://user-images.githubusercontent.com/8602001/180572494-92b7bbb3-8390-421c-9adc-222bbe49653d.png)

You can try adding other random files / directories and rerunning the above commands again

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [x] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.