### PR TITLE
Add code coverage ignore file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ endif()
 #============================================================================
 # Configure the build
 #============================================================================
+configure_file("${PROJECT_SOURCE_DIR}/coverage.ignore.in"
+               ${PROJECT_BINARY_DIR}/coverage.ignore)
+
 ign_configure_build(QUIT_IF_BUILD_ERRORS
   COMPONENTS cli)
 

--- a/coverage.ignore.in
+++ b/coverage.ignore.in
@@ -1,0 +1,1 @@
+cli/include/vendored-cli/ignition/utils/cli/*


### PR DESCRIPTION
Signed-off-by: youhy <haoyuan2019@outlook.com>

<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# New feature

Part of [gz-sim#1575](https://github.com/gazebosim/gz-sim/issues/1575)

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

Allow users to add `coverage.ignore.in` each repo to ignore files for the code coverage report. See https://github.com/gazebosim/gz-cmake/pull/279 for details.

Ignore the `cli/include/vendored-cli/ignition/utils/cli/` folder.

Need to wait for a forward-porting for https://github.com/gazebosim/gz-cmake/pull/279 from citadel to fortress to be merged.

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
