### PR TITLE
Implement ExtraTestMacros for all platforms

### DIFF
--- a/include/gz/utils/ExtraTestMacros.hh
+++ b/include/gz/utils/ExtraTestMacros.hh
@@ -20,6 +20,14 @@
 
 #include <gz/utils/detail/ExtraTestMacros.hh>
 
+/// \brief Restrict the execution of the test to just the Windows platform
+/// Other platforms will get the test compiled but it won't be run
+/// as part of the test suite execution.
+/// The macro uses the Disabled_ prefix provided by googletest. See
+/// https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md
+#define GZ_UTILS_TEST_ENABLED_ONLY_ON_WINDOWS(TestName) \
+  DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_WINDOWS(TestName)
+
 /// \brief Restrict the execution of the test for the Windows platform.
 /// The test will be compiled on Windows too but will never be run as
 /// part of the test suite. The macro uses the Disabled_ prefix provided
@@ -28,8 +36,16 @@
 #define GZ_UTILS_TEST_DISABLED_ON_WIN32(TestName) \
   DETAIL_GZ_UTILS_TEST_DISABLED_ON_WIN32(TestName)
 
+/// \brief Restrict the execution of the test to just the MacOS platform
+/// Other platforms will get the test compiled but it won't be run
+/// as part of the test suite execution.
+/// The macro uses the Disabled_ prefix provided by googletest. See
+/// https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md
+#define GZ_UTILS_TEST_ENABLED_ONLY_ON_MAC(TestName) \
+  DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_MAC(TestName)
+
 /// \brief Restrict the execution of the test for the Mac platform.
-/// The test will be compiled on Windows too but will never be run as
+/// The test will be compiled on Mac too but will never be run as
 /// part of the test suite. The macro uses the Disabled_ prefix provided
 /// by googletest. See
 /// https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md
@@ -43,5 +59,13 @@
 /// https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md
 #define GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(TestName) \
   DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(TestName)
+
+/// \brief Restrict the execution of the test for the Linux platform
+/// The test will be compiled on Linux too but will never be run as
+/// part of the test suite. The macro uses the Disabled_ prefix provided
+/// by googletest. See
+/// https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md
+#define GZ_UTILS_TEST_DISABLED_ON_LINUX(TestName) \
+  DETAIL_GZ_UTILS_TEST_DISABLED_ON_LINUX(TestName)
 
 #endif  // GZ_UTILS_EXTRATESTMACROS_HH

--- a/include/gz/utils/detail/ExtraTestMacros.hh
+++ b/include/gz/utils/detail/ExtraTestMacros.hh
@@ -26,11 +26,15 @@
 
   #define DETAIL_GZ_UTILS_TEST_DISABLED_ON_WIN32(TestName) \
       DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
+  #define DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_WIN32(TestName) \
+      TestName
 
 #else
 
   #define DETAIL_GZ_UTILS_TEST_DISABLED_ON_WIN32(TestName) \
       TestName
+  #define DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_WIN32(TestName) \
+      DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
 
 #endif  // defined _WIN32
 
@@ -38,21 +42,29 @@
 
   #define DETAIL_GZ_UTILS_TEST_DISABLED_ON_MAC(TestName) \
       DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
+  #define DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_MAC(TestName) \
+      TestName
 
 #else
 
   #define DETAIL_GZ_UTILS_TEST_DISABLED_ON_MAC(TestName) \
       TestName
+  #define DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_MAC(TestName) \
+      DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
 
 #endif  // defined __APPLE__
 
 #if defined __linux__
 
+  #define DETAIL_GZ_UTILS_TEST_DISABLED_ON_LINUX(TestName) \
+      DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
   #define DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(TestName) \
       TestName
 
 #else
 
+  #define DETAIL_GZ_UTILS_TEST_DISABLED_ON_LINUX(TestName) \
+      TestName
   #define DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_LINUX(TestName) \
       DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-transport/pull/336

## Summary

When working on https://github.com/gazebosim/gz-transport/pull/336, I noticed that we don't have the full set of macros for enabling/disabling tests on a per-platform basis.  These may not all get used, but it at least completes the set.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
