### PR TITLE
Fix CXX_STANDARD in core library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
 gz_get_libsources_and_unittests(sources gtest_sources)
 
-gz_create_core_library(SOURCES ${sources} CXX_STANDARD ${c++standard})
+gz_create_core_library(SOURCES ${sources} CXX_STANDARD ${CMAKE_CXX_STANDARD})
 gz_build_tests(TYPE UNIT SOURCES ${gtest_sources})


### PR DESCRIPTION
# 🦟 Bug fix

Fixes `.pc` file (see https://github.com/osrf/homebrew-simulation/pull/2016#issuecomment-1232130214)

## Summary

We used to use a `c++standard` cmake variable, but recently changed to using `CMAKE_CXX_STANDARD` but hadn't updated the `CXX_STANDARD` argument to `gz_create_core_library`. This caused a `pkg-config` compilation test to fail during a brew bottle build, but it should be fixed now.

Confirm by checking for a `-std=c++17` flag in the output of `pkg-config --cflags gz-utils2`.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
