### PR TITLE
Add missing config.hh include to gz headers

### DIFF
--- a/include/gz/utils/ImplPtr.hh
+++ b/include/gz/utils/ImplPtr.hh
@@ -21,6 +21,7 @@
 #include <memory>
 #include <utility>
 
+#include <gz/utils/config.hh>
 #include <gz/utils/detail/DefaultOps.hh>
 #include <gz/utils/SuppressWarning.hh>
 #include <gz/utils/Export.hh>

--- a/include/gz/utils/NeverDestroyed.hh
+++ b/include/gz/utils/NeverDestroyed.hh
@@ -22,6 +22,8 @@
 #include <type_traits>
 #include <utility>
 
+#include <gz/utils/config.hh>
+
 namespace ignition
 {
 namespace utils


### PR DESCRIPTION
# 🦟 Bug fix

Fixes some gz headers

## Summary

The `gz/utils/*.hh` headers on `ign-utils1` that use the `ignition` namespace need to include `gz/utils/config.hh` to get the `gz` namespace. I found this while trying to use `gz::utils::ImplPtr` in sdformat12:

* https://github.com/gazebosim/sdformat/actions/runs/3681027316/jobs/6227265470#step:8:88

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
