### PR TITLE
Report test results from GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,18 @@ jobs:
           codecov-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true
+      - name: Strip workspace prefix
+        if: success() || failure() # always run even if the previous step fails
+        run: |
+          mkdir test_results/
+          cp ./build/test_results/*.xml ./test_results/
+          sed -i 's+/github/workspace/++g' ./test_results/*.xml
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          check_name: 'Ubuntu Focal Results'
+          report_paths: 'build/test_results/*.xml'
   jammy-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Jammy CI
@@ -25,3 +37,15 @@ jobs:
       - name: Compile and test
         id: ci
         uses: gazebo-tooling/action-gz-ci@jammy
+      - name: Strip workspace prefix
+        if: success() || failure() # always run even if the previous step fails
+        run: |
+          mkdir test_results/
+          cp ./build/test_results/*.xml ./test_results/
+          sed -i 's+/github/workspace/++g' ./test_results/*.xml
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v3
+        if: success() || failure() # always run even if the previous step fails
+        with:
+          check_name: 'Ubuntu Jammy Results'
+          report_paths: 'test_results/*.xml'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,18 +16,6 @@ jobs:
           codecov-enabled: true
           cpplint-enabled: true
           doxygen-enabled: true
-      - name: Strip workspace prefix
-        if: success() || failure() # always run even if the previous step fails
-        run: |
-          mkdir test_results/
-          cp ./build/test_results/*.xml ./test_results/
-          sed -i 's+/github/workspace/++g' ./test_results/*.xml
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        if: success() || failure() # always run even if the previous step fails
-        with:
-          check_name: 'Ubuntu Focal Results'
-          report_paths: 'build/test_results/*.xml'
   jammy-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Jammy CI
@@ -36,16 +24,5 @@ jobs:
         uses: actions/checkout@v3
       - name: Compile and test
         id: ci
-        uses: gazebo-tooling/action-gz-ci@jammy
-      - name: Strip workspace prefix
-        if: success() || failure() # always run even if the previous step fails
-        run: |
-          mkdir test_results/
-          cp ./build/test_results/*.xml ./test_results/
-          sed -i 's+/github/workspace/++g' ./test_results/*.xml
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v3
-        if: success() || failure() # always run even if the previous step fails
-        with:
-          check_name: 'Ubuntu Jammy Results'
-          report_paths: 'test_results/*.xml'
+        uses: gazebo-tooling/action-gz-ci@composite_jammy
+

--- a/test/integration/actions_TEST.cc
+++ b/test/integration/actions_TEST.cc
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+
+#include <gtest/gtest.h>
+
+TEST(Actions, Skip)
+{
+  GTEST_SKIP();
+}
+
+TEST(Actions, Fail)
+{
+  EXPECT_EQ(1u, 0u);
+}


### PR DESCRIPTION
This introduces a `composite_jammy` action, which allows for all the arguments to be forwarded to our standard Jammy CI (https://github.com/gazebo-tooling/action-gz-ci/tree/composite_jammy).  At the end, it aggregates the test failures and reports them as part of the Github Action results