### PR TITLE
Extra test macros for ARM32/ARM64

### DIFF
--- a/include/gz/utils/ExtraTestMacros.hh
+++ b/include/gz/utils/ExtraTestMacros.hh
@@ -68,4 +68,36 @@
 #define GZ_UTILS_TEST_DISABLED_ON_LINUX(TestName) \
   DETAIL_GZ_UTILS_TEST_DISABLED_ON_LINUX(TestName)
 
+/// \brief Restrict the execution of the test to just the ARM32 architecture
+/// Other platforms will get the test compiled but it won't be run
+/// as part of the test suite execution.
+/// The macro uses the Disabled_ prefix provided by googletest. See
+/// https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md
+#define GZ_UTILS_TEST_ENABLED_ONLY_ON_ARM32(TestName) \
+  DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_ARM32(TestName)
+
+/// \brief Restrict the execution of the test for the ARM32 architecture
+/// The test will be compiled on Linux too but will never be run as
+/// part of the test suite. The macro uses the Disabled_ prefix provided
+/// by googletest. See
+/// https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md
+#define GZ_UTILS_TEST_DISABLED_ON_ARM32(TestName) \
+  DETAIL_GZ_UTILS_TEST_DISABLED_ON_ARM32(TestName)
+
+/// \brief Restrict the execution of the test to just the ARM64 architecture
+/// Other platforms will get the test compiled but it won't be run
+/// as part of the test suite execution.
+/// The macro uses the Disabled_ prefix provided by googletest. See
+/// https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md
+#define GZ_UTILS_TEST_ENABLED_ONLY_ON_ARM64(TestName) \
+  DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_ARM64(TestName)
+
+/// \brief Restrict the execution of the test for the ARM64 architecture
+/// The test will be compiled on Linux too but will never be run as
+/// part of the test suite. The macro uses the Disabled_ prefix provided
+/// by googletest. See
+/// https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md
+#define GZ_UTILS_TEST_DISABLED_ON_ARM64(TestName) \
+  DETAIL_GZ_UTILS_TEST_DISABLED_ON_ARM64(TestName)
+
 #endif  // GZ_UTILS_EXTRATESTMACROS_HH

--- a/include/gz/utils/ExtraTestMacros.hh
+++ b/include/gz/utils/ExtraTestMacros.hh
@@ -77,7 +77,7 @@
   DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_ARM32(TestName)
 
 /// \brief Restrict the execution of the test for the ARM32 architecture
-/// The test will be compiled on Linux too but will never be run as
+/// The test will be compiled on ARM32 too but will never be run as
 /// part of the test suite. The macro uses the Disabled_ prefix provided
 /// by googletest. See
 /// https://chromium.googlesource.com/external/github.com/google/googletest/+/HEAD/googletest/docs/advanced.md

--- a/include/gz/utils/detail/ExtraTestMacros.hh
+++ b/include/gz/utils/detail/ExtraTestMacros.hh
@@ -70,5 +70,37 @@
 
 #endif  // defined __linux__
 
+#if defined __arm__ || defined _M_ARM
+
+  #define DETAIL_GZ_UTILS_TEST_DISABLED_ON_ARM32(TestName) \
+      DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
+  #define DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_ARM32(TestName) \
+      TestName
+
+#else
+
+  #define DETAIL_GZ_UTILS_TEST_DISABLED_ON_ARM32(TestName) \
+      TestName
+  #define DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_ARM32(TestName) \
+      DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
+
+#endif  // defined __arm__
+
+#if defined __aarch64__ || defined _M_ARM64
+
+  #define DETAIL_GZ_UTILS_TEST_DISABLED_ON_ARM64(TestName) \
+      DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
+  #define DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_ARM64(TestName) \
+      TestName
+
+#else
+
+  #define DETAIL_GZ_UTILS_TEST_DISABLED_ON_ARM64(TestName) \
+      TestName
+  #define DETAIL_GZ_UTILS_TEST_ENABLED_ONLY_ON_ARM64(TestName) \
+      DETAIL_GZ_UTILS_ADD_DISABLED_PREFIX(TestName)
+
+#endif  // defined __aarch64__
+
 
 #endif  // GZ_UTILS_DETAIL_EXTRATESTMACROS_HH


### PR DESCRIPTION
# 🎉 New feature

Closes #82 

## Summary

Adds macros for enabling/disabling tests based on ARM32/ARM64 platforms.

## Test it

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.