### PR TITLE
Clang-tidy and include-what-you-use warnings

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,7 +12,7 @@ package(
     features = GZ_FEATURES,
 )
 
-licenses(["notice"])  # Apache-2.0
+licenses(["notice"])
 
 exports_files(["LICENSE"])
 

--- a/cli/include/gz/utils/cli/GzFormatter.hpp
+++ b/cli/include/gz/utils/cli/GzFormatter.hpp
@@ -19,6 +19,7 @@
 #define GZ_UTILS_CLI_GZ_FORMATTER_HPP_
 
 #include <algorithm>
+#include <iterator>
 #include <string>
 #include <sstream>
 #include <vector>
@@ -26,6 +27,7 @@
 
 #include "gz/utils/cli/App.hpp"
 #include "gz/utils/cli/FormatterFwd.hpp"
+#include "gz/utils/cli/StringTools.hpp"
 #include "gz/utils/Export.hh"
 
 //////////////////////////////////////////////////

--- a/src/Environment.cc
+++ b/src/Environment.cc
@@ -18,8 +18,7 @@
 #include <gz/utils/Environment.hh>
 
 #include <cstdlib>
-#include <iostream>
-
+#include <string>
 
 namespace gz
 {

--- a/src/Environment_TEST.cc
+++ b/src/Environment_TEST.cc
@@ -19,6 +19,8 @@
 
 #include <gz/utils/Environment.hh>
 
+#include <string>
+
 using namespace gz;
 
 /////////////////////////////////////////////////

--- a/src/NeverDestroyed_TEST.cc
+++ b/src/NeverDestroyed_TEST.cc
@@ -19,7 +19,12 @@
 
 #include <gtest/gtest.h>
 
+#include <cstdint>
+#include <exception>
+#include <initializer_list>
 #include <random>
+#include <string>
+#include <vector>
 #include <unordered_map>
 
 using namespace gz;

--- a/test/integration/implptr/ImplPtr_TEST.cc
+++ b/test/integration/implptr/ImplPtr_TEST.cc
@@ -17,8 +17,9 @@
 
 #include <gtest/gtest.h>
 
-#include <gz/utils/ImplPtr.hh>
 #include "implptr_test_classes.hh"
+
+#include <utility>
 
 using namespace gz::implptr_test_classes;
 

--- a/test/integration/implptr/implptr_test_classes.cc
+++ b/test/integration/implptr/implptr_test_classes.cc
@@ -17,6 +17,8 @@
 
 #include "implptr_test_classes.hh"
 
+#include <gz/utils/ImplPtr.hh>
+
 #include <string>
 #include <thread>
 
@@ -153,4 +155,3 @@ void CopyableObjectAlt::SetString(const std::string &_value)
 {
   (*dataPtr).svalue = _value;
 }
-

--- a/test/integration/implptr/implptr_test_classes.hh
+++ b/test/integration/implptr/implptr_test_classes.hh
@@ -42,7 +42,7 @@ namespace gz
       public: int GetInt() const;
 
       /// \brief Set the int value held by the pimpl
-      public: void SetInt(const int _value);
+      public: void SetInt(int _value);
 
       /// \brief Get the string value held by the pimpl
       public: const std::string &GetString() const;
@@ -72,7 +72,7 @@ namespace gz
       public: int GetInt() const;
 
       /// \brief Set the int value held by the pimpl
-      public: void SetInt(const int _value);
+      public: void SetInt(int _value);
 
       /// \brief Get the string value held by the pimpl
       public: const std::string &GetString() const;
@@ -102,7 +102,7 @@ namespace gz
       public: int GetInt() const;
 
       /// \brief Set the int value held by the pimpl
-      public: void SetInt(const int _value);
+      public: void SetInt(int _value);
 
       /// \brief Get the string value held by the pimpl
       public: const std::string &GetString() const;


### PR DESCRIPTION
Will also bump subprocess.h when this lands: https://github.com/sheredom/subprocess.h/pull/75