### PR TITLE
bazel: build and test subprocess functionality

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -41,6 +41,7 @@ gz_export_header(
 public_headers_no_gen = glob([
     "include/gz/utils/*.hh",
     "include/gz/utils/detail/*.hh",
+    "include/gz/utils/detail/*.h",
 ])
 
 gz_include_header(

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -111,3 +111,23 @@ cc_test(
         "@gtest//:gtest_main",
     ],
 )
+
+cc_binary(
+  name = "subprocess_main",
+  srcs = ["test/integration/subprocess/subprocess_main.cc"],
+  deps = [
+      GZ_ROOT + "utils/cli",
+  ]
+)
+
+cc_test(
+    name = "subprocess_TEST",
+    srcs = ["test/integration/subprocess_TEST.cc"],
+    deps = [
+        ":utils",
+        ":subprocess_main",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+  local_defines = ['SUBPROCESS_EXECUTABLE_PATH=\\"utils/subprocess_main\\"'],
+)


### PR DESCRIPTION
# 🦟 Bug fix

## Summary

When subprocess functionality was introduced, it wasn't tested with bazel builds.  This fixes that.

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.