### PR TITLE
Minor lint feedback

### DIFF
--- a/include/gz/utils/detail/subprocess.h
+++ b/include/gz/utils/detail/subprocess.h
@@ -187,7 +187,7 @@ subprocess_weak int subprocess_terminate(struct subprocess_s *const process);
 ///
 /// The only safe way to read from the standard output of a process during it's
 /// execution is to use the `subprocess_option_enable_async` option in
-/// conjuction with this method.
+/// conjunction with this method.
 subprocess_weak unsigned
 subprocess_read_stdout(struct subprocess_s *const process, char *const buffer,
                        unsigned size);
@@ -201,7 +201,7 @@ subprocess_read_stdout(struct subprocess_s *const process, char *const buffer,
 ///
 /// The only safe way to read from the standard error of a process during it's
 /// execution is to use the `subprocess_option_enable_async` option in
-/// conjuction with this method.
+/// conjunction with this method.
 subprocess_weak unsigned
 subprocess_read_stderr(struct subprocess_s *const process, char *const buffer,
                        unsigned size);

--- a/src/Environment.cc
+++ b/src/Environment.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <string>
+#include <utility>
 #include <vector>
 
 #ifdef _WIN32
@@ -189,7 +190,9 @@ EnvironmentStrings envMapToStrings(const EnvironmentMap &_envMap)
   std::sort(sorted.begin(), sorted.end());
   for (auto [key, value] : sorted)
   {
-    ret.push_back(key + "=" + value);
+    key += '=';
+    key += value;
+    ret.push_back(key);
   }
   return ret;
 }


### PR DESCRIPTION
Misspelled words, missing header, and small optimization to remove inadvertent copies.