### PR TITLE
Add the ability to send a signal to a subprocess

### DIFF
--- a/include/gz/utils/Subprocess.hh
+++ b/include/gz/utils/Subprocess.hh
@@ -36,6 +36,20 @@ namespace gz
 namespace utils
 {
 
+enum class Signals
+{
+  #ifdef WIN32
+  CTRL_C_EVENT = 0,
+  CTRL_BREAK_EVENT = 1,
+  CTRL_CLOSE_EVENT = 2,
+  CTRL_LOGOFF_EVENT = 5,
+  CTRL_SHUTDOWN_EVENT = 6,
+  #else
+  SIGNAL_SIGINT = 2,
+  SIGNAL_SIGQUIT = 3,
+  #endif
+};
+
 /// \brief Create a RAII-type object that encapsulates a subprocess.
 class Subprocess
 {
@@ -181,6 +195,26 @@ class Subprocess
       return subprocess_alive(this->process);
     else
       return false;
+  }
+
+  public: bool Signal(int signum)
+  {
+    if (this->process != nullptr)
+      return subprocess_signal(this->process, signum) != 0;
+    else
+      return false;
+
+  }
+
+  public: bool SendExitSignal()
+  {
+    int signal = 0;
+    #ifdef WIN32
+    signal = static_cast<int>(Signals::CTRL_C_EVENT);
+    #else
+    signal = static_cast<int>(Signals::SIGNAL_SIGINT);
+    #endif
+    return this->Signal(signal);
   }
 
   public: bool Terminate()

--- a/include/gz/utils/detail/subprocess.h
+++ b/include/gz/utils/detail/subprocess.h
@@ -923,6 +923,17 @@ FILE *subprocess_stderr(const struct subprocess_s *const process) {
   }
 }
 
+int subprocess_signal(const subprocess_s *const process,
+                      int signum)
+{
+#if defined(_WIN32)
+  return GenerateConsoleCtrlEvent(signum, process->hProcess);
+#else
+  return kill(process->child, signum);
+#endif
+
+}
+
 int subprocess_join(struct subprocess_s *const process,
                     int *const out_return_code) {
 #if defined(_WIN32)

--- a/test/integration/subprocess_TEST.cc
+++ b/test/integration/subprocess_TEST.cc
@@ -200,5 +200,39 @@ TEST(Subprocess, Environment)
     EXPECT_EQ(std::string::npos, cout.find("GZ_BAZ_KEY=GZ_BAZ_VAL"));
     EXPECT_NE(std::string::npos, cout.find("QUX_KEY=QUX_VAL"));
   }
+}
 
+/////////////////////////////////////////////////
+TEST(Subprocess, Signal)
+{
+  auto start = std::chrono::steady_clock::now();
+  auto proc = Subprocess({kExecutablePath,
+                          "--output=cerr",
+                          "--iterations=100",
+                          "--iteration-ms=10"});
+  EXPECT_TRUE(proc.Alive());
+
+  // Sleep for >1 iteration before sending signal
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+  // Signal
+  proc.SendExitSignal();
+
+  // Block until the executable is done
+  auto ret = proc.Join();
+  EXPECT_EQ(1u, ret);
+
+  auto end = std::chrono::steady_clock::now();
+  auto elapsed =
+    std::chrono::duration_cast<std::chrono::milliseconds>(end - start);
+
+  // Check that process finished in less than half a second
+  // If the signal failed to send, then the process would run for over 1 second
+  EXPECT_LT(elapsed.count(), 500);
+
+  EXPECT_FALSE(proc.Alive());
+  auto cout = proc.Stdout();
+  auto cerr = proc.Stderr();
+  EXPECT_TRUE(cout.empty());
+  EXPECT_FALSE(cerr.empty());
 }


### PR DESCRIPTION
# 🎉 New feature

## Summary

Adds `Subprocess::Signal` and `Subprocess::SendExitSignal`.

We discovered that using `kill -9` in transport tests was too aggressive and not letting the subprocess shut down cleanly.  This allows you to send SIGINT on Linux or CTRL_C_EVENT/CTRL_BREAK_EVENT on Windows to cause the subprocess to shut down cleanly.

## Test it

Added a unit test.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.

