### PR TITLE
Update changelog and prepare for prereleases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(gz-cmake4 REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX)
+gz_configure_project(VERSION_SUFFIX pre1)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,41 @@
 
 ## Gazebo Utils 3.0.0 (20XX-XX-XX)
 
+1. Move spdlog::logger to gz-utils
+    * [Pull request #134](https://github.com/gazebosim/gz-utils/pull/134)
+
+1. Require cmake version 3.22.1
+    * [Pull request #132](https://github.com/gazebosim/gz-utils/pull/132)
+
+1. Add package.xml
+    * [Pull request #125](https://github.com/gazebosim/gz-utils/pull/125)
+    * [Pull request #131](https://github.com/gazebosim/gz-utils/pull/131)
+
+1. bazel: build and test subprocess functionality
+    * [Pull request #123](https://github.com/gazebosim/gz-utils/pull/123)
+    * [Pull request #124](https://github.com/gazebosim/gz-utils/pull/124)
+
+1. Update CI badges in README
+    * [Pull request #120](https://github.com/gazebosim/gz-utils/pull/120)
+
+1. Use HIDE_SYMBOLS_BY_DEFAULT
+    * [Pull request #115](https://github.com/gazebosim/gz-utils/pull/115)
+    * [Pull request #121](https://github.com/gazebosim/gz-utils/pull/121)
+
+1. Remove ignition
+    * [Pull request #100](https://github.com/gazebosim/gz-utils/pull/100)
+
+1. Bumps in ionic: use gz-cmake4
+    * [Pull request #111](https://github.com/gazebosim/gz-utils/pull/111)
+
+1. Infrastructure
+    * [Pull request #112](https://github.com/gazebosim/gz-utils/pull/112)
+    * [Pull request #119](https://github.com/gazebosim/gz-utils/pull/119)
+    * [Pull request #129](https://github.com/gazebosim/gz-utils/pull/129)
+
+1. ⬆️  Bump main to 3.0.0~pre1
+    * [Pull request #76](https://github.com/gazebosim/gz-utils/pull/76)
+
 ## Gazebo Utils 2.x
 
 ## Gazebo Utils 2.2.0 (2023-11-08)


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1092

Comparison to 2.2.0: https://github.com/gazebosim/gz-utils/compare/gz-utils2_2.2.0...main

## Checklist
- [ ] Asked team if this is a good time for a release
- [ ] There are no changes to be ported from the previous major version
- [ ] No PRs targeted at this major version are close to getting in
- [ ] Bumped minor for new features, patch for bug fixes
- [ ] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.