### PR TITLE
Prepare for 3.0.0~pre2 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(gz-cmake4 REQUIRED)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-gz_configure_project(VERSION_SUFFIX pre1)
+gz_configure_project(VERSION_SUFFIX pre2)
 
 #============================================================================
 # Set project-specific options

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,18 @@
 
 ## Gazebo Utils 3.0.0 (20XX-XX-XX)
 
+1. **Baseline:** this includes all changes from 2.2.0 and earlier.
+
+1. Logger updates
+    * [Pull request #139](https://github.com/gazebosim/gz-utils/pull/139)
+
+1. Update badges to point to gz-utils3 branch
+    * [Pull request #137](https://github.com/gazebosim/gz-utils/pull/137)
+    * [Pull request #138](https://github.com/gazebosim/gz-utils/pull/138)
+
+1. Update changelog and add prepare for prereleases
+    * [Pull request #136](https://github.com/gazebosim/gz-utils/pull/136)
+
 1. Move spdlog::logger to gz-utils
     * [Pull request #134](https://github.com/gazebosim/gz-utils/pull/134)
 


### PR DESCRIPTION

# 🎈 Release

Preparation for 3.0.0~pre2 release.

Comparison to 3.0.0-pre1: https://github.com/gazebosim/gz-utils/compare/gz-utils3_3.0.0-pre1...prep_3.0.0pre2


## Checklist
- [x] Asked team if this is a good time for a release
- [x] There are no changes to be ported from the previous major version
- [x] No PRs targeted at this major version are close to getting in
- [x] Bumped minor for new features, patch for bug fixes
- [x] Updated changelog
- [ ] Updated migration guide (as needed)
- [ ] Link to PR updating dependency versions in appropriate repository in [gazebo-release](https://github.com/gazebo-release) (as needed): <LINK>

<!-- Please refer to https://github.com/gazebo-tooling/release-tools#for-each-release for more information -->

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
