### PR TITLE
Use common formatter for console and file sinks

### DIFF
--- a/log/include/gz/utils/log/Logger.hh
+++ b/log/include/gz/utils/log/Logger.hh
@@ -57,6 +57,10 @@ class GZ_UTILS_LOG_VISIBLE Logger
   /// \return The spdlog logger.
   public: [[nodiscard]] std::shared_ptr<spdlog::logger> RawLoggerPtr() const;
 
+  /// \brief Set the severity level of the Console sink
+  /// \param [in] _level Severity level
+  public: void SetConsoleSinkLevel(spdlog::level::level_enum _level);
+
   /// \brief Implementation Pointer.
   GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
 };


### PR DESCRIPTION
# 🦟 Bug fix

Fixes #<NUMBER>

## Summary
The severity level of the file sink is now set to trace so that it logs to file regardless of the severity level of the console.

This patch also adds an API to set the severity level of just the console sink.


## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.