### PR TITLE
Update logger level and flush_on values

### DIFF
--- a/log/src/Logger.cc
+++ b/log/src/Logger.cc
@@ -69,8 +69,9 @@ Logger::Logger(const std::string &_loggerName)
   this->dataPtr->sinks->add_sink(this->dataPtr->consoleSink);
 
   // Configure the logger.
+  this->dataPtr->logger->set_level(spdlog::level::trace);
   this->dataPtr->consoleSink->set_level(spdlog::level::err);
-  this->dataPtr->logger->flush_on(spdlog::level::err);
+  this->dataPtr->logger->flush_on(spdlog::level::debug);
 
   this->dataPtr->logger->set_formatter(this->dataPtr->formatter->clone());
 }


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
The logger level change is needed because the file sink's level is `trace` and apparently `spdlog` will use the lower severity level of the logger and the sink.

The `flush_on` change is needed to cause spdlog to write to file more frequently.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
