### PR TITLE
Include file name in log format

### DIFF
--- a/log/src/Logger.cc
+++ b/log/src/Logger.cc
@@ -28,7 +28,8 @@ namespace gz::utils::log
 namespace {
   /// \brief Default log format
   /// Example output
-  constexpr std::string_view kDefaultLogFormat{"%^(%Y-%m-%d %T.%e) [%l] %v%$"};
+constexpr std::string_view kDefaultLogFormat{
+    "%^(%Y-%m-%d %T.%e) [%l] [%s:%#] %v%$"};
 }
 /// \brief Private data for the Logger class.
 class Logger::Implementation


### PR DESCRIPTION


# 🦟 Bug fix

Fixes https://github.com/gazebosim/gz-common/issues/631

## Summary

Based on formatting wiki https://github.com/gabime/spdlog/wiki/3.-Custom-formatting %s is for Basename of the source file and %# is for line number.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.