### PR TITLE
Catch spdlog exception thrown when creating file

### DIFF
--- a/log/src/Logger.cc
+++ b/log/src/Logger.cc
@@ -88,14 +88,14 @@ void Logger::SetLogDestination(const std::string &_filename)
   if (!_filename.empty())
   {
     try
-    {      
+    {
       this->dataPtr->fileSink =
         std::make_shared<spdlog::sinks::basic_file_sink_mt>(_filename, true);
       this->dataPtr->fileSink->set_formatter(this->dataPtr->formatter->clone());
       this->dataPtr->fileSink->set_level(spdlog::level::trace);
       this->dataPtr->sinks->add_sink(this->dataPtr->fileSink);
     }
-    catch(const std::exception &_e)
+    catch (const std::exception &_e)
     {
       std::cerr << "Error creating log file: " << _e.what() << std::endl;
     }

--- a/log/src/Logger.cc
+++ b/log/src/Logger.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  *
  */
+#include <exception>
+#include <iostream>
 #include <memory>
 #include <string>
 
@@ -85,11 +87,18 @@ void Logger::SetLogDestination(const std::string &_filename)
 
   if (!_filename.empty())
   {
-    this->dataPtr->fileSink =
-      std::make_shared<spdlog::sinks::basic_file_sink_mt>(_filename, true);
-    this->dataPtr->fileSink->set_formatter(this->dataPtr->formatter->clone());
-    this->dataPtr->fileSink->set_level(spdlog::level::trace);
-    this->dataPtr->sinks->add_sink(this->dataPtr->fileSink);
+    try
+    {      
+      this->dataPtr->fileSink =
+        std::make_shared<spdlog::sinks::basic_file_sink_mt>(_filename, true);
+      this->dataPtr->fileSink->set_formatter(this->dataPtr->formatter->clone());
+      this->dataPtr->fileSink->set_level(spdlog::level::trace);
+      this->dataPtr->sinks->add_sink(this->dataPtr->fileSink);
+    }
+    catch(const std::exception &_e)
+    {
+      std::cerr << "Error creating log file: " << _e.what() << std::endl;
+    }
   }
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Fixes https://github.com/gazebosim/gazebo_test_cases/issues/1701

## Summary

Catches exception if the provided path could not be created. Also see https://github.com/gazebosim/gz-sim/pull/2589

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
