### PR TITLE
Use spdlog_vendor in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,7 +13,7 @@
 
   <build_depend>gz-cmake4</build_depend>
 
-  <depend>spdlog</depend>
+  <depend>spdlog_vendor</depend>
 
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
# 🦟 Bug fix


## Summary
`spdlog` is not being properly found on ROS windows builds. Example: https://ci.ros2.org/view/nightly/job/nightly_win_rel/3158/cmake/new/

Per @clalancette's recommendation, this patch changes the package.xml entry to `spdlog_vendor`.

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
