### PR TITLE
Add EoL and use SetConsoleSinkLevel

### DIFF
--- a/examples/log/main.cc
+++ b/examples/log/main.cc
@@ -22,7 +22,7 @@
 int main(int argc, char** argv)
 {
   gz::utils::log::Logger logger("my_logger");
-  logger.SetConsoleSinkLevel(spdlog::level::trace);
+  logger.SetConsoleSinkLevel(spdlog::level::info);
 
   std::filesystem::path logDir = std::filesystem::temp_directory_path();
   std::filesystem::path logFile = "my_log.txt";

--- a/examples/log/main.cc
+++ b/examples/log/main.cc
@@ -22,16 +22,16 @@
 int main(int argc, char** argv)
 {
   gz::utils::log::Logger logger("my_logger");
-  logger.RawLogger().set_level(spdlog::level::trace);
+  logger.SetConsoleSinkLevel(spdlog::level::trace);
 
   std::filesystem::path logDir = std::filesystem::temp_directory_path();
   std::filesystem::path logFile = "my_log.txt";
   std::filesystem::path logPath = logDir / logFile;
 
   logger.SetLogDestination(logPath);
-  logger.RawLogger().trace("trace");
-  logger.RawLogger().info("info");
-  logger.RawLogger().warn("warn");
-  logger.RawLogger().error("error");
-  logger.RawLogger().critical("critical");
+  logger.RawLogger().trace("trace\n");
+  logger.RawLogger().info("info\n");
+  logger.RawLogger().warn("warn\n");
+  logger.RawLogger().error("error\n");
+  logger.RawLogger().critical("critical\n");
 }


### PR DESCRIPTION
<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

This patch:
 1. Adds newlines to the logging messages used in the log example.
 2. Uses `SetConsoleSinkLevel()` to only change the verbosity level of the console.

This is the result we should see in the console:
```
(2024-09-22 20:41:34.090) [info] [:] info
(2024-09-22 20:41:34.090) [warning] [:] warn
(2024-09-22 20:41:34.090) [error] [:] error
(2024-09-22 20:41:34.090) [critical] [:] critical
```

And this is the result we should see in `/tmp/my_log.txt`:
```
(2024-09-22 20:41:34.090) [trace] [:] trace
(2024-09-22 20:41:34.090) [info] [:] info
(2024-09-22 20:41:34.090) [warning] [:] warn
(2024-09-22 20:41:34.090) [error] [:] error
(2024-09-22 20:41:34.090) [critical] [:] critical
```

If we change the verbosity level using the original call `logger.RawLogger().set_level(spdlog::level::trace);` the result is confusing because the console only shows:
```
(2024-09-22 20:44:34.801) [error] [:] error
(2024-09-22 20:44:34.801) [critical] [:] critical
```

The reason for this is because we have a logger level set to `trace` and the console sink levels set to `err` in `Logger.cc`. `spdlog` seems to choose the verbosity with higher priority between sinks and logger.

## Summary
<!-- Describe your fix, including an explanation of how to reproduce the bug
before and after the PR.-->

## Checklist
- [ ] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.