### PR TITLE
Add expectations to subprocess test

### DIFF
--- a/test/integration/subprocess_TEST.cc
+++ b/test/integration/subprocess_TEST.cc
@@ -52,8 +52,8 @@ TEST(Subprocess, CreateInvalidSpaces)
   auto cout = proc.Stdout();
   auto cerr = proc.Stdout();
 
-  EXPECT_TRUE(cout.empty());
-  EXPECT_TRUE(cerr.empty());
+  EXPECT_TRUE(cout.empty()) << cout;
+  EXPECT_TRUE(cerr.empty()) << cerr;
 }
 
 /////////////////////////////////////////////////
@@ -71,7 +71,7 @@ TEST(Subprocess, CreateValid)
   auto cerr = proc.Stdout();
 
   EXPECT_FALSE(cout.empty());
-  EXPECT_TRUE(cerr.empty());
+  EXPECT_TRUE(cerr.empty()) << cerr;
 }
 
 /////////////////////////////////////////////////
@@ -91,7 +91,8 @@ TEST(Subprocess, Cout)
   auto cout = proc.Stdout();
   auto cerr = proc.Stderr();
   EXPECT_FALSE(cout.empty());
-  EXPECT_TRUE(cerr.empty());
+  EXPECT_NE(std::string::npos, cout.find("Iteration: ")) << cout;
+  EXPECT_TRUE(cerr.empty()) << cerr;
 }
 
 /////////////////////////////////////////////////
@@ -110,8 +111,9 @@ TEST(Subprocess, Cerr)
   EXPECT_FALSE(proc.Alive());
   auto cout = proc.Stdout();
   auto cerr = proc.Stderr();
-  EXPECT_TRUE(cout.empty());
+  EXPECT_TRUE(cout.empty()) << cout;
   EXPECT_FALSE(cerr.empty());
+  EXPECT_NE(std::string::npos, cerr.find("Iteration: ")) << cerr;
 }
 
 /////////////////////////////////////////////////


### PR DESCRIPTION
# 🦟 Bug fix

Minor improvements to `INTEGRATION_subprocess_TEST`

## Summary

This adds expectations to the subprocess test instead of just checking that cout/cerr are not empty. It also adds streaming of variable values if expectations fail.

## Checklist
- [X] Signed all commits for DCO
- [X] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [X] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [X] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
