### PR TITLE
Disable CLI11 vendoring by default

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,2 +1,3 @@
+libcli11-dev
 libgz-cmake4-dev
 libspdlog-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ gz_configure_project(VERSION_SUFFIX pre1)
 option(
   GZ_UTILS_VENDOR_CLI11
   "If true, use the vendored version of CLI11, otherwise use an external one"
-  true)
+  OFF)
 
 #============================================================================
 # Search for project-specific dependencies

--- a/Migration.md
+++ b/Migration.md
@@ -5,6 +5,18 @@ Deprecated code produces compile-time warnings. These warning serve as
 notification to users that their code should be upgraded. The next major
 release will remove the deprecated code.
 
+## Gazebo Utils 3.X to 4.X
+
+The default value of `GZ_UTILS_VENDOR_CLI11` is now set to `OFF`, so that
+an external version of `cli11` will be preferred by default. This is in
+preparation to remove the vendored version (see
+[issue #135](https://github.com/gazebosim/gz-utils/issues/135)).
+
+## Gazebo Utils 2.X to 3.X
+
+The `ignition` namespace, `ignition/` header files, `IGN_` prefixed macros,
+and `IgnitionFormatter` class have been removed.
+
 ## Gazebo Utils 1.X to 2.X
 
 * The `ignition` namespace is deprecated and will be removed in future versions.

--- a/cli/src/cli_TEST.cc
+++ b/cli/src/cli_TEST.cc
@@ -131,7 +131,7 @@ TEST(cli, options)
   });
 
   app.formatter(std::make_shared<GzFormatter>(&app));
-  EXPECT_NO_THROW(app.help());
+  EXPECT_NO_THROW(std::cout << app.help());
   EXPECT_NO_THROW(app.parse(argv));
 }
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-utils/issues/135

## Summary

CLI11 is available upstream, so don't vendor by default.

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
