### PR TITLE
Use 24.04 for doxygen CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
         uses: gazebo-tooling/action-gz-ci@jammy
         with:
           codecov-enabled: true
-          doxygen-enabled: true
   noble-ci:
     runs-on: ubuntu-latest
     name: Ubuntu Noble CI
@@ -31,5 +30,6 @@ jobs:
         id: ci
         uses: gazebo-tooling/action-gz-ci@noble
         with:
-           cppcheck-enabled: true
-           cpplint-enabled: true
+          cppcheck-enabled: true
+          cpplint-enabled: true
+          doxygen-enabled: true

--- a/tutorials/installation.md
+++ b/tutorials/installation.md
@@ -11,9 +11,9 @@ Windows via either a binary distribution or from source.
 
 - [Source Install](#source-install)
 
-  - [Prerequisites](#prerequisites)
+[Documentation](#documentation)
 
-  - [Building from Source](#building-from-source)
+[Testing](#testing)
 
 # Install
 

--- a/tutorials/installation.md
+++ b/tutorials/installation.md
@@ -5,7 +5,7 @@
 This tutorial describes how to install Gazebo Utils on Linux, Mac OS X and
 Windows via either a binary distribution or from source.
 
-[Install](#install)
+[Installation instructions](#installation-instructions)
 
 - [Binary Install](#binary-install)
 
@@ -15,7 +15,7 @@ Windows via either a binary distribution or from source.
 
 [Testing](#testing)
 
-# Install
+# Installation instructions
 
 We recommend following the [Binary Install](#binary-install) instructions to get up and running as quickly and painlessly as possible.
 


### PR DESCRIPTION
# 🎉 New feature

Part of https://github.com/gazebo-tooling/release-tools/issues/1222

## Summary

Jammy isn't officially supported for Ionic, so move doxygen check to use Noble.

## Test it

Verify that CI passes

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
