### PR TITLE
package.xml: depend on cli11

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
 
   <build_depend>gz-cmake</build_depend>
 
+  <depend>cli11</depend>
   <depend>spdlog</depend>
 
   <export>


### PR DESCRIPTION
# 🦟 Bug fix

Follow up to #167.

## Summary

Since we now search for `cli11` as a system dependency by default, add `cli11` as a dependency in `package.xml` to aid in resolving dependencies via rosdep.


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
