### PR TITLE
Re-disable vendoring of cli11 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ gz_configure_project(VERSION_SUFFIX pre1)
 option(
   GZ_UTILS_VENDOR_CLI11
   "If true, use the vendored version of CLI11, otherwise use an external one"
-  ON)
+  OFF)
 
 #============================================================================
 # Search for project-specific dependencies

--- a/Migration.md
+++ b/Migration.md
@@ -7,12 +7,10 @@ release will remove the deprecated code.
 
 ## Gazebo Utils 3.X to 4.X
 
-<!--
 The default value of `GZ_UTILS_VENDOR_CLI11` is now set to `OFF`, so that
 an external version of `cli11` will be preferred by default. This is in
 preparation to remove the vendored version (see
 [issue #135](https://github.com/gazebosim/gz-utils/issues/135)).
--->
 
 ## Gazebo Utils 2.X to 3.X
 


### PR DESCRIPTION
# 🦟 Bug fix

Part of https://github.com/gazebosim/gz-sim/issues/2918.

## Summary

This redisables vending of cli11 by reverting commit bdcef68a8bb0273d79bfbfabd9db83b82d68ddbd (#178).


## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [X] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` messages.
