### PR TITLE
[bazel] Few fixes in MODULE.bazel

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier", "buildifier_test")
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_configure_header", "gz_export_header")
 load("@rules_license//rules:license.bzl", "license")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,6 +6,8 @@ module(
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
 bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)
-bazel_dep(name = "rules_gazebo", version = "0.0.2")
 bazel_dep(name = "rules_license", version = "1.0.0", dev_dependency = True)
+
+bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_gazebo", version = "0.0.2")
 bazel_dep(name = "spdlog", version = "1.15.3")

--- a/cli/BUILD.bazel
+++ b/cli/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["__subpackages__"],

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
 package(
     default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:private"],

--- a/log/BUILD.bazel
+++ b/log/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@rules_gazebo//gazebo:headers.bzl", "gz_export_header")
 
 package(


### PR DESCRIPTION
# 🦟 Bug fix

## Summary
Few small fixes in MODULE.bazel as pre-work to add automation to push new releases to BCR.

- Drop `repo_name`, which removes the need to [patch MODULE.bazel](https://github.com/bazelbuild/bazel-central-registry/blob/main/modules/gz-utils/4.0.0-pre1/patches/module_dot_bazel.patch) when pushing a release to BCR. `repo_name` is not a required field and can be added on the client side during import if needed to disambiguate packages.
- bump `buildifier_prebuilt` version (required for BCR presubmit to pass with bazel 8.x). This also requires importing `cc_*` rules from `rules_cc` since native repo rules will be flagged as warning in bazel 8 and dropped completely in bazel 9.
- add `dev_dependency` attributes where it makes sense, see https://bazel.build/rules/lib/globals/module#bazel_dep for more info. This was suggested in code review: https://github.com/bazelbuild/bazel-central-registry/pull/6114#discussion_r2407889903

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.

