### PR TITLE
[bazel] Remove dev_dependency tags in MODULE.bazel to fix downstream …

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,10 +4,9 @@ module(
     name = "gz-utils",
 )
 
-bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
-bazel_dep(name = "googletest", version = "1.14.0", dev_dependency = True)
-bazel_dep(name = "rules_license", version = "1.0.0", dev_dependency = True)
-
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
+bazel_dep(name = "googletest", version = "1.14.0")
+bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_cc", version = "0.1.1")
 bazel_dep(name = "rules_gazebo", version = "0.0.2")
 bazel_dep(name = "spdlog", version = "1.15.3")


### PR DESCRIPTION
…builds

# 🦟 Bug fix

## Summary
I added `dev_dependency = True` in https://github.com/gazebosim/gz-utils/pull/189 for a few bazel deps as recommended in a BCR AI code review. 
But it turns out that doing so breaks downstream builds, e.g. in gz-math:
```
ERROR: error loading package '@@gz-utils~//': Unable to find package for @@[unknown repo 'buildifier_prebuilt' requested from @@gz-utils~]//:rules.bzl: 
The repository '@@[unknown repo 'buildifier_prebuilt' requested from @@gz-utils~]' could not be resolved: 
No repository visible as '@buildifier_prebuilt' from repository '@@gz-utils~'.
```

So this change removes the `dev_dependency` attributes to fix downstream build.

I also opened a bug in BCR about the incorrect suggestion: https://github.com/bazelbuild/bazel-central-registry/issues/6119

## Checklist
- [X] Signed all commits for DCO
- [ ] Added tests
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)

**Note to maintainers**: Remember to use **Squash-Merge** and edit the commit message to match the pull request summary while retaining `Signed-off-by` and `Generated-by` messages.