### PR TITLE
Add SetConsoleColorMode to Logger

### DIFF
--- a/log/include/gz/utils/log/Logger.hh
+++ b/log/include/gz/utils/log/Logger.hh
@@ -65,6 +65,10 @@ class GZ_UTILS_LOG_VISIBLE Logger
   /// \param [in] _level Severity level
   public: void SetConsoleSinkLevel(spdlog::level::level_enum _level);
 
+  /// \brief Set console color output mode.
+  /// \param [in] _mode Color mode.
+  public: void SetConsoleColorMode(spdlog::color_mode _mode);
+
   /// \brief Implementation Pointer.
   GZ_UTILS_UNIQUE_IMPL_PTR(dataPtr)
 };

--- a/log/src/Logger.cc
+++ b/log/src/Logger.cc
@@ -133,4 +133,13 @@ void Logger::SetConsoleSinkLevel(spdlog::level::level_enum _level)
   }
 }
 
+/////////////////////////////////////////////////
+void Logger::SetConsoleColorMode(spdlog::color_mode _mode)
+{
+  if (this->dataPtr->consoleSink)
+  {
+    this->dataPtr->consoleSink->set_color_mode(_mode);
+  }
+}
+
 }  // namespace gz::utils::log


### PR DESCRIPTION


<!--
Please remove the appropriate section.
For example, if this is a new feature, remove all sections except for the "New feature" section

If this is your first time opening a PR, be sure to check the contribution guide:
https://gazebosim.org/docs/all/contributing
-->

# 🎉 New feature

This exposes control over the color output mode of the console sink,
allowing callers to override spdlog's automatic terminal detection.

Required by gazebosim/gz-common#792
Related: gazebosim/gz-common#611

## Summary
<!--Explain changes made, the expected behavior, and provide any other additional
context (e.g., screenshots, gifs) if appropriate.-->

## Test it
<!--Explain how reviewers can test this new feature manually.-->

## Checklist
- [x] Signed all commits for DCO
- [ ] Added a screen capture or video to the PR description that demonstrates the feature
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if the library has them)
- [ ] `codecheck` passed (See [contributing](https://gazebosim.org/docs/all/contributing#contributing-code))
- [ ] All tests passed (See [test coverage](https://gazebosim.org/docs/all/contributing#test-coverage))
- [ ] Updated Bazel files (if adding new files). Created an issue otherwise.
- [ ] While waiting for a review on your PR, please help review [another open pull request](https://github.com/pulls?q=is%3Aopen+is%3Apr+user%3Agazebosim+archived%3Afalse+) to support the maintainers
- [ ] Was GenAI used to generate this PR? If so, make sure to add "Generated-by" to your commits. (See [this policy](https://osralliance.org/wp-content/uploads/2025/05/OSRF-Policy-on-the-Use-of-Generative-Tools-Generative-AI-in-Contributions.pdf) for more info.)
