### PR TITLE
Use rotary unversioned packages for CI

### DIFF
--- a/.github/ci/packages.apt
+++ b/.github/ci/packages.apt
@@ -1,3 +1,3 @@
 libcli11-dev
-libgz-rotary-cmake-dev
+libgz-cmake-dev
 libspdlog-dev


### PR DESCRIPTION
Part of https://github.com/gazebo-tooling/release-tools/issues/1446. Follow-up to https://github.com/gazebosim/gz-utils/pull/206 and following the pattern of https://github.com/gazebosim/gz-math/pull/729.